### PR TITLE
Delete unit test target api level 26 from GitHub action #16

### DIFF
--- a/.github/workflows/android_unit_test.yml
+++ b/.github/workflows/android_unit_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [30]
+        api-level: [26, 27, 28, 29, 30]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/android_unit_test.yml
+++ b/.github/workflows/android_unit_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [26, 30]
+        api-level: [30]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
support all api level from 26 to 30 for github action unit test